### PR TITLE
Remover suporte a tipos booleanos e ajustar conversões de tipo

### DIFF
--- a/Controlador.py
+++ b/Controlador.py
@@ -12,7 +12,7 @@ def detectar_tipo_python(valor):
     tipo_map = {
         'int': 'INT',
         'float': 'FLOAT',
-        'bool': 'BOOLEAN',
+        'bool': 'INT',
         'str': 'STRING'
     }
     
@@ -25,7 +25,6 @@ def processar_expressao(expressao):
         expressao_proc = re.sub(r'([0-9\.]+)\+?to_float\+?([0-9\.]+)', r'(float(\1)+0*\2)', expressao, flags=re.IGNORECASE)
         expressao_proc = re.sub(r'([0-9\.]+)\+?to_int\+?([0-9\.]+)', r'(int(\1)+0*\2)', expressao_proc, flags=re.IGNORECASE)
         expressao_proc = re.sub(r'([0-9\.]+)\+?to_short\+?([0-9\.]+)', r'(int(\1)+0*\2)', expressao_proc, flags=re.IGNORECASE)
-        expressao_proc = re.sub(r'([0-9\.]+)\+?to_boolean\+?([0-9\.]+)', r'(bool(\1) or bool(\2))', expressao_proc, flags=re.IGNORECASE)
         
         # Remove espaços e padroniza operadores
         expressao_limpa = expressao_proc.replace(" ", "").replace("×", "*").replace("÷", "/")
@@ -46,8 +45,8 @@ def processar_expressao(expressao):
         valor_resultado = resultado
         
         # Converte para formato JSON-safe
-        if tipo_resultado == 'BOOLEAN':
-            valor_resultado = bool(resultado)
+        if tipo_resultado == 'INT' and isinstance(resultado, bool):
+            valor_resultado = 1 if resultado else 0
         elif tipo_resultado == 'INT':
             valor_resultado = int(resultado)
         elif tipo_resultado == 'FLOAT':

--- a/Inventory/Art/Orbs/orb_bool.png.import
+++ b/Inventory/Art/Orbs/orb_bool.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dg8f57mx07tf7"
+uid="uid://badunptlh60yk"
 path="res://.godot/imported/orb_bool.png-23d38974bc71a2406d1d7978e282dfac.ctex"
 metadata={
 "vram_texture": false

--- a/Inventory/Data/Item_data.json
+++ b/Inventory/Data/Item_data.json
@@ -40,11 +40,5 @@
 	"Value": 0,
 	"Operator": "to_short",
 	"Grid": "0,0"
-  },
-  "item_operator_to_boolean": {
-	"Name": "To Boolean",
-	"Value": 0,
-	"Operator": "to_boolean",
-	"Grid": "0,0"
   }
 }

--- a/Inventory/Items/item.gd
+++ b/Inventory/Items/item.gd
@@ -4,13 +4,12 @@ extends Node2D
 @onready var cylinder_visual: Control = $CylinderVisual
 
 # Enum para identificar o tipo de dado do orb
-enum DataType {INT, FLOAT, BOOLEAN, STRING, OPERATOR, DOUBLE, BINARY, SHORT_INT, FP8, FP16, RAW}
+enum DataType {INT, FLOAT, STRING, OPERATOR, DOUBLE, BINARY, SHORT_INT, FP8, FP16, RAW}
 
 var item_ID : String
 var data_type: DataType = DataType.INT  # Tipo padrão é INT
 var value : int = 0
 var value_float : float = 0.0
-var value_bool : bool = false
 var value_string : String = ""
 var value_double : float = 0.0  # Precisão dupla (ocupa 2 slots)
 var value_short : int = 0
@@ -95,8 +94,6 @@ func get_item_info() -> Dictionary:
 				info.id = "item_number_" + str(value)
 			DataType.FLOAT:
 				info.id = "item_float_" + str(value_float)
-			DataType.BOOLEAN:
-				info.id = "item_bool_" + ("true" if value_bool else "false")
 			DataType.STRING:
 				info.id = "item_string_" + str(value_string.hash())
 			DataType.OPERATOR:
@@ -122,10 +119,6 @@ func get_item_info() -> Dictionary:
 			info.tipo = "FLOAT (Decimal)"
 			info.valor = full_val
 			info.detalhes = "Número decimal: " + full_val
-		DataType.BOOLEAN:
-			info.tipo = "BOOLEAN (Booleano)"
-			info.valor = "true" if value_bool else "false"
-			info.detalhes = "Valor booleano: " + ("Verdadeiro" if value_bool else "Falso")
 		DataType.STRING:
 			info.tipo = "STRING (Texto)"
 			info.valor = '"' + value_string + '"'
@@ -173,7 +166,6 @@ func load_item(a_ItemID: String) -> void:
 		data_type = DataType.OPERATOR
 		value = 0
 		value_float = 0.0
-		value_bool = false
 		value_string = ""
 	# Verifica o tipo de dado
 	elif data.has("DataType"):
@@ -183,26 +175,17 @@ func load_item(a_ItemID: String) -> void:
 				data_type = DataType.FLOAT
 				value_float = float(data.get("Value", 0.0))
 				value = 0
-				value_bool = false
-				value_string = ""
-			"BOOLEAN", "BOOL":
-				data_type = DataType.BOOLEAN
-				value_bool = bool(data.get("Value", false))
-				value = 0
-				value_float = 0.0
 				value_string = ""
 			"STRING", "STR":
 				data_type = DataType.STRING
 				value_string = str(data.get("Value", ""))
 				value = 0
 				value_float = 0.0
-				value_bool = false
 			"DOUBLE":
 				data_type = DataType.DOUBLE
 				value_double = float(data.get("Value", 0.0))
 				value = int(value_double)
 				value_float = value_double
-				value_bool = false
 				value_string = ""
 				# DOUBLE ocupa 2 slots horizontais
 				item_grids = [Vector2(0,0), Vector2(1,0)]
@@ -212,7 +195,6 @@ func load_item(a_ItemID: String) -> void:
 				value = int(data.get("Value", 0))
 				value_binary = int_to_binary(value, binary_bits)
 				value_float = float(value)
-				value_bool = false
 				value_string = ""
 				item_grids = [Vector2(0,0)]
 			"SHORT_INT", "SHORT":
@@ -220,28 +202,24 @@ func load_item(a_ItemID: String) -> void:
 				value_short = int(data.get("Value", 0))
 				value = value_short
 				value_float = float(value_short)
-				value_bool = false
 				value_string = ""
 				item_grids = [Vector2(0,0)]
 			"FP8":
 				data_type = DataType.FP8
 				value_float = float(data.get("Value", 0.0))
 				value = int(value_float)
-				value_bool = false
 				value_string = ""
 				item_grids = [Vector2(0,0)]
 			"FP16":
 				data_type = DataType.FP16
 				value_float = float(data.get("Value", 0.0))
 				value = int(value_float)
-				value_bool = false
 				value_string = ""
 				item_grids = [Vector2(0,0)]
 			"RAW":
 				data_type = DataType.RAW
 				value_float = float(data.get("Value", 0.0))
 				value = int(value_float)
-				value_bool = false
 				value_string = ""
 				item_grids = [Vector2(0,0)]
 			_:
@@ -249,14 +227,12 @@ func load_item(a_ItemID: String) -> void:
 				data_type = DataType.INT
 				value = int(data.get("Value", 0))
 				value_float = 0.0
-				value_bool = false
 				value_string = ""
 	else:
 		# Fallback: assume que é um número inteiro (compatibilidade)
 		data_type = DataType.INT
 		value = int(data.get("Value", 0))
 		value_float = 0.0
-		value_bool = false
 		value_string = ""
 		operator = ""
 
@@ -266,7 +242,6 @@ func set_value_directly(new_value: int):
 	"""Define o valor diretamente (para resultados de expressões) - mantém compatibilidade"""
 	value = new_value
 	value_float = float(new_value)
-	value_bool = false
 	value_string = ""
 	operator = ""
 	data_type = DataType.INT
@@ -282,39 +257,28 @@ func set_value_by_type(new_value, tipo: DataType):
 		DataType.INT:
 			value = int(new_value)
 			value_float = float(new_value)
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.FLOAT:
 			value_float = float(new_value)
 			value = int(value_float)
-			value_bool = false
-			value_string = ""
-			item_grids = [Vector2(0,0)]
-		DataType.BOOLEAN:
-			value_bool = bool(new_value)
-			value = 1 if value_bool else 0
-			value_float = 1.0 if value_bool else 0.0
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.STRING:
 			value_string = str(new_value)
 			value = 0
 			value_float = 0.0
-			value_bool = false
 			item_grids = [Vector2(0,0)]
 		DataType.OPERATOR:
 			operator = str(new_value)
 			value = 0
 			value_float = 0.0
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.DOUBLE:
 			value_double = float(new_value)
 			value = int(value_double)
 			value_float = value_double
-			value_bool = false
 			value_string = ""
 			# DOUBLE ocupa 2 slots horizontais
 			item_grids = [Vector2(0,0), Vector2(1,0)]
@@ -322,7 +286,6 @@ func set_value_by_type(new_value, tipo: DataType):
 			value = int(new_value)
 			value_binary = int_to_binary(value, binary_bits)
 			value_float = float(value)
-			value_bool = false
 			value_string = ""
 			# BINARY ocupa 1 slot (antes era N slots)
 			item_grids = [Vector2(0,0)]
@@ -330,25 +293,21 @@ func set_value_by_type(new_value, tipo: DataType):
 			value_short = int(new_value)
 			value = value_short
 			value_float = float(value_short)
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.FP8:
 			value_float = float(new_value)
 			value = int(value_float)
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.FP16:
 			value_float = float(new_value)
 			value = int(value_float)
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 		DataType.RAW:
 			value_float = float(new_value)
 			value = int(value_float)
-			value_bool = false
 			value_string = ""
 			item_grids = [Vector2(0,0)]
 	
@@ -364,7 +323,6 @@ func set_operator_directly(new_operator: String):
 	data_type = DataType.OPERATOR
 	value = 0
 	value_float = 0.0
-	value_bool = false
 	value_string = ""
 	item_ID = "item_operator_" + new_operator
 	update_label_display()
@@ -404,8 +362,6 @@ func update_label_display():
 			value_label.add_theme_color_override("font_color", Color.BLUE)
 		DataType.FLOAT:
 			value_label.add_theme_color_override("font_color", Color.RED)
-		DataType.BOOLEAN:
-			value_label.add_theme_color_override("font_color", Color.GREEN)
 		DataType.STRING:
 			value_label.add_theme_color_override("font_color", Color.YELLOW)
 		DataType.DOUBLE:
@@ -452,7 +408,6 @@ func operator_display_label() -> String:
 		"to_int": return "int"
 		"to_float": return "flt"
 		"to_short": return "sh"
-		"to_boolean", "to_bool": return "bool"
 	if operator.begins_with("to_") and operator.length() > 3:
 		return operator.substr(3)
 	if operator.length() <= 5:
@@ -475,7 +430,7 @@ func _slot_item_count(slot: TextureRect) -> int:
 
 func _base_type_slot_scale() -> float:
 	match data_type:
-		DataType.BOOLEAN, DataType.FP8:
+		DataType.FP8:
 			return 0.25
 		DataType.SHORT_INT, DataType.FP16:
 			return 0.5
@@ -539,8 +494,6 @@ func _apply_orb_sprite(dims: Vector2 = Vector2.ZERO) -> bool:
 			path = "res://Inventory/Art/Orbs/orb_int.png"
 		DataType.FLOAT:
 			path = "res://Inventory/Art/Orbs/orb_float.png"
-		DataType.BOOLEAN:
-			path = "res://Inventory/Art/Orbs/orb_bool.png"
 		DataType.BINARY:
 			path = "res://Inventory/Art/Orbs/orb_binary.png"
 		DataType.OPERATOR:
@@ -795,8 +748,6 @@ func get_size_bytes() -> int:
 			return 2
 		DataType.FP16:
 			return 2
-		DataType.BOOLEAN:
-			return 1
 		DataType.FP8:
 			return 1
 		DataType.RAW:

--- a/Inventory/Items/orb_value_format.gd
+++ b/Inventory/Items/orb_value_format.gd
@@ -49,8 +49,6 @@ static func full_value_string(item: Node) -> String:
 			return _float_full(item.value_float)
 		item.DataType.DOUBLE:
 			return _float_full(item.value_double)
-		item.DataType.BOOLEAN:
-			return "true" if item.value_bool else "false"
 		item.DataType.STRING:
 			return "\"" + item.value_string + "\""
 		item.DataType.OPERATOR:
@@ -75,8 +73,6 @@ static func python_repr_string(item: Node) -> String:
 			return _float_full(item.value_float)
 		item.DataType.DOUBLE:
 			return _float_full(item.value_double)
-		item.DataType.BOOLEAN:
-			return "True" if item.value_bool else "False"
 		item.DataType.STRING:
 			return "repr: " + item.value_string
 		item.DataType.OPERATOR:

--- a/Inventory/controlador.gd
+++ b/Inventory/controlador.gd
@@ -119,13 +119,6 @@ func converter_resultado_para_tipo(valor: Variant, tipo: String) -> Variant:
 			return float(valor)
 		"DOUBLE":
 			return float(valor)
-		"BOOLEAN":
-			if typeof(valor) == TYPE_BOOL:
-				return bool(valor)
-			elif typeof(valor) == TYPE_INT or typeof(valor) == TYPE_FLOAT:
-				return bool(valor)
-			else:
-				return bool(valor)
 		"STRING":
 			return str(valor)
 		"BINARY":
@@ -144,8 +137,6 @@ func avaliar_expressao_rapida(expressao: String) -> Dictionary:
 	expressao = regex.sub(expressao, "(floor($1) + 0 * $2)", true)
 	regex.compile("([0-9\\.]+)\\+?to_short\\+?([0-9\\.]+)")
 	expressao = regex.sub(expressao, "(floor($1) + 0 * $2)", true)
-	regex.compile("([0-9\\.]+)\\+?to_boolean\\+?([0-9\\.]+)")
-	expressao = regex.sub(expressao, "($1 != 0 or $2 != 0)", true)
 	
 	expressao = expressao.replace("×", "*").replace("÷", "/").replace(" ", "")
 	
@@ -154,11 +145,10 @@ func avaliar_expressao_rapida(expressao: String) -> Dictionary:
 		var str_valor = expressao.substr(1, expressao.length() - 2)
 		return {"resultado": str_valor, "tipo": "STRING"}
 	
-	# Tenta detectar booleanos
 	if expressao.to_lower() == "true":
-		return {"resultado": true, "tipo": "BOOLEAN"}
+		return {"resultado": 1, "tipo": "INT"}
 	if expressao.to_lower() == "false":
-		return {"resultado": false, "tipo": "BOOLEAN"}
+		return {"resultado": 0, "tipo": "INT"}
 	
 	# Tenta avaliar como expressão matemática
 	var expression = Expression.new()
@@ -174,7 +164,8 @@ func avaliar_expressao_rapida(expressao: String) -> Dictionary:
 			elif typeof(resultado) == TYPE_FLOAT:
 				tipo_resultado = "FLOAT"
 			elif typeof(resultado) == TYPE_BOOL:
-				tipo_resultado = "BOOLEAN"
+				tipo_resultado = "INT"
+				resultado = 1 if resultado else 0
 			elif typeof(resultado) == TYPE_STRING:
 				tipo_resultado = "STRING"
 			

--- a/Inventory/fases/backpack_phase.tscn
+++ b/Inventory/fases/backpack_phase.tscn
@@ -22,7 +22,6 @@ use_converter = false
 allow_float = false
 allow_double = false
 allow_short = false
-allow_bool = false
 allow_fp8 = false
 allow_fp16 = false
 allow_calc = false

--- a/Inventory/fases/inventory_menu.gd
+++ b/Inventory/fases/inventory_menu.gd
@@ -132,9 +132,9 @@ func create_item_on_hand_randomly():
 			5: random_item = "item_number_5"
 			6: random_item = "item_double_3.14159"
 			7: random_item = "item_binary_10"
-			8: random_item = "item_operator_to_boolean"
-			9: random_item = "item_operator_to_float"
-			10: random_item = "item_operator_to_int"
+			8: random_item = "item_operator_to_float"
+			9: random_item = "item_operator_to_int"
+			10: random_item = "item_number_10"
 		
 		if new_item.has_method("load_item"):
 			new_item.load_item(random_item)
@@ -310,8 +310,6 @@ func check_combinations():
 									sequence.append(str(item.value))
 								item.DataType.FLOAT:
 									sequence.append(str(item.value_float))
-								item.DataType.BOOLEAN:
-									sequence.append("true" if item.value_bool else "false")
 								item.DataType.STRING:
 									sequence.append('"' + item.value_string + '"')
 						slots_na_sequencia.append(slot)
@@ -368,8 +366,6 @@ func check_combinations():
 									sequence.append(str(item.value))
 								item.DataType.FLOAT:
 									sequence.append(str(item.value_float))
-								item.DataType.BOOLEAN:
-									sequence.append("true" if item.value_bool else "false")
 								item.DataType.STRING:
 									sequence.append('"' + item.value_string + '"')
 						slots_na_sequencia.append(slot)
@@ -412,8 +408,8 @@ func validar_tipos_expressao(sequence: Array) -> Dictionary:
 			tipos_encontrados.append("STRING")
 			valores_encontrados.append(token)
 		elif token.to_lower() == "true" or token.to_lower() == "false":
-			tipos_encontrados.append("BOOLEAN")
-			valores_encontrados.append(token)
+			tipos_encontrados.append("INT")
+			valores_encontrados.append("1" if token.to_lower() == "true" else "0")
 		elif "." in token and token.replace(".", "").replace("-", "").is_valid_float():
 			tipos_encontrados.append("FLOAT")
 			valores_encontrados.append(token)
@@ -484,8 +480,6 @@ func avaliar_expressao_com_tipo(expr: String) -> Dictionary:
 	expr = regex.sub(expr, "(floor($1) + 0 * $2)", true)
 	regex.compile("([0-9\\.]+)\\+?to_short\\+?([0-9\\.]+)")
 	expr = regex.sub(expr, "(floor($1) + 0 * $2)", true)
-	regex.compile("([0-9\\.]+)\\+?to_boolean\\+?([0-9\\.]+)")
-	expr = regex.sub(expr, "($1 != 0 or $2 != 0)", true)
 	
 	expr = expr.replace(" ", "")
 	
@@ -494,11 +488,10 @@ func avaliar_expressao_com_tipo(expr: String) -> Dictionary:
 		var str_valor = expr.substr(1, expr.length() - 2)
 		return {"resultado": str_valor, "tipo": "STRING"}
 	
-	# Detecta booleanos
 	if expr.to_lower() == "true":
-		return {"resultado": true, "tipo": "BOOLEAN"}
+		return {"resultado": 1, "tipo": "INT"}
 	if expr.to_lower() == "false":
-		return {"resultado": false, "tipo": "BOOLEAN"}
+		return {"resultado": 0, "tipo": "INT"}
 	
 	var expression = Expression.new()
 	var error = expression.parse(expr, [])
@@ -511,7 +504,8 @@ func avaliar_expressao_com_tipo(expr: String) -> Dictionary:
 			elif typeof(resultado) == TYPE_FLOAT:
 				tipo_resultado = "FLOAT"
 			elif typeof(resultado) == TYPE_BOOL:
-				tipo_resultado = "BOOLEAN"
+				tipo_resultado = "INT"
+				resultado = 1 if resultado else 0
 			elif typeof(resultado) == TYPE_STRING:
 				tipo_resultado = "STRING"
 			
@@ -572,10 +566,6 @@ func create_result_item_typed(resultado: Variant, tipo_resultado: String):
 				# Limita casas decimais para exibição
 				valor_float = clamp(valor_float, -999.99, 999.99)
 				new_item.set_value_by_type(valor_float, tipo_enum)
-			"BOOLEAN":
-				tipo_enum = new_item.DataType.BOOLEAN
-				var valor_bool = bool(resultado)
-				new_item.set_value_by_type(valor_bool, tipo_enum)
 			"STRING":
 				tipo_enum = new_item.DataType.STRING
 				var valor_str = str(resultado)

--- a/Inventory/fases/phase2.tscn
+++ b/Inventory/fases/phase2.tscn
@@ -22,7 +22,6 @@ use_converter = false
 allow_float = false
 allow_double = false
 allow_short = false
-allow_bool = false
 allow_fp8 = false
 allow_fp16 = false
 allow_calc = false

--- a/Inventory/fases/phase_2.gd
+++ b/Inventory/fases/phase_2.gd
@@ -133,7 +133,6 @@ func _initialize_game(backpack: InventoryGrid, pool: InventoryGrid):
 			if config.use_converter: converter_option_btn.add_item("Float")
 			if config.allow_double: converter_option_btn.add_item("Double")
 			if config.allow_short: converter_option_btn.add_item("Short")
-			if config.allow_bool: converter_option_btn.add_item("Boolean")
 			if config.allow_fp8: converter_option_btn.add_item("FP8")
 			if config.allow_fp16: converter_option_btn.add_item("FP16")
 			converter_option_btn.add_item("Int") # Sempre permitir a volta pro Int
@@ -356,9 +355,6 @@ func _make_item_from_entry(entry: String) -> Node2D:
 		shorthand.set_value_by_type(float(value_str), shorthand.DataType.DOUBLE)
 	elif type_str == "s":
 		shorthand.set_value_by_type(int(value_str), shorthand.DataType.SHORT_INT)
-	elif type_str == "b":
-		var b_val = (value_str.to_lower() == "true" or value_str == "1")
-		shorthand.set_value_by_type(b_val, shorthand.DataType.BOOLEAN)
 	else:
 		push_warning("Tipo não suportado no CSV: %s" % type_str)
 		shorthand.queue_free()

--- a/Inventory/fases/phase_base.gd
+++ b/Inventory/fases/phase_base.gd
@@ -19,7 +19,6 @@ var converter_slot: TextureRect = null
 var converter_option_btn: OptionButton = null
 var double_slot: TextureRect = null
 var short_slot: TextureRect = null
-var boolean_slot: TextureRect = null
 var calc_slot_1: TextureRect = null
 var calc_slot_2 = null
 var calc_slot_result: TextureRect = null
@@ -444,9 +443,7 @@ func _check_calculator() -> void:
 			_clear_calc_result()
 			var new_item: Node2D = preload("res://Inventory/Items/Item.tscn").instantiate()
 			var final_val = deg.degraded_value
-			if target_type == ItemRef.DataType.BOOLEAN:
-				new_item.set_value_by_type(final_val != 0, target_type)
-			elif target_type in [ItemRef.DataType.INT, ItemRef.DataType.SHORT_INT]:
+			if target_type in [ItemRef.DataType.INT, ItemRef.DataType.SHORT_INT]:
 				new_item.set_value_by_type(int(final_val), target_type)
 			else:
 				new_item.set_value_by_type(final_val, target_type)
@@ -481,7 +478,6 @@ func _priority_for_data_type(dt: int) -> int:
 	if dt == ItemRef.DataType.FP8: return 70
 	if dt == ItemRef.DataType.INT: return 60
 	if dt == ItemRef.DataType.SHORT_INT: return 50
-	if dt == ItemRef.DataType.BOOLEAN: return 40
 	return 0
 
 
@@ -492,7 +488,6 @@ func _get_type_string(dt: int) -> String:
 	if dt == ItemRef.DataType.FP8: return "FP8"
 	if dt == ItemRef.DataType.INT: return "Int"
 	if dt == ItemRef.DataType.SHORT_INT: return "Short"
-	if dt == ItemRef.DataType.BOOLEAN: return "Boolean"
 	return "Float"
 
 
@@ -534,8 +529,6 @@ func _apply_target_type_to_item(item: Node, target_type_str: String, final_val: 
 			item.set_value_by_type(final_val, ItemRef.DataType.DOUBLE)
 		"Short":
 			item.set_value_by_type(int(final_val), ItemRef.DataType.SHORT_INT)
-		"Boolean":
-			item.set_value_by_type(final_val != 0, ItemRef.DataType.BOOLEAN)
 		"FP8":
 			item.set_value_by_type(final_val, ItemRef.DataType.FP8)
 			_apply_fp_bits_from_config(item, "fp8")

--- a/Inventory/fases/phase_config.gd
+++ b/Inventory/fases/phase_config.gd
@@ -26,7 +26,6 @@ extends Resource
 @export var allow_float: bool = false
 @export var allow_double: bool = false
 @export var allow_short: bool = false
-@export var allow_bool: bool = false
 @export var allow_fp8: bool = false
 @export var allow_fp16: bool = false
 @export var allow_calc: bool = false

--- a/Inventory/fases/phase_runner.gd
+++ b/Inventory/fases/phase_runner.gd
@@ -48,7 +48,6 @@ func advance_from_phase() -> void:
 	# Verifica se a fase atual permite avanço (subclasses podem implementar is_phase_success)
 	var current_scene = get_tree().get_current_scene()
 	if current_scene and current_scene.has_method("is_phase_success"):
-		# Forçar tipo booleano explícito para evitar erro de inferência
 		var ok: bool = current_scene.is_phase_success()
 		if not ok:
 			# Emite signal em vez de apenas push_warning para UI feedback

--- a/Inventory/fases/raw_knapsack_phase.gd
+++ b/Inventory/fases/raw_knapsack_phase.gd
@@ -172,8 +172,6 @@ func _allowed_types() -> Array:
 		types.append({"type": ItemRef.DataType.FP8, "name": "FP8", "color": Color.VIOLET})
 	if config.allow_fp16:
 		types.append({"type": ItemRef.DataType.FP16, "name": "FP16", "color": Color.GOLD})
-	if config.allow_bool:
-		types.append({"type": ItemRef.DataType.BOOLEAN, "name": "Bool", "color": Color.GREEN})
 	return types
 
 
@@ -454,8 +452,6 @@ func _on_spawn_pressed() -> void:
 func _numeric_from_item(item: Node) -> float:
 	if item.data_type in [ItemRef.DataType.FLOAT, ItemRef.DataType.DOUBLE, ItemRef.DataType.FP8, ItemRef.DataType.FP16, ItemRef.DataType.RAW]:
 		return item.value_float
-	if item.data_type == ItemRef.DataType.BOOLEAN:
-		return 1.0 if item.value_bool else 0.0
 	return float(item.value)
 
 

--- a/Inventory/fases/raw_knapsack_phase_config.gd
+++ b/Inventory/fases/raw_knapsack_phase_config.gd
@@ -19,7 +19,6 @@ extends Resource
 @export var allow_double: bool = false
 @export var allow_fp8: bool = false
 @export var allow_fp16: bool = false
-@export var allow_bool: bool = false
 
 @export var fp8_exp_bits: int = 4
 @export var fp8_mant_bits: int = 3

--- a/Inventory/fases/scenarios/demo_sequencia_professor.tres
+++ b/Inventory/fases/scenarios/demo_sequencia_professor.tres
@@ -81,7 +81,6 @@ allow_float = true
 allow_double = false
 allow_fp8 = false
 allow_fp16 = false
-allow_bool = false
 
 [sub_resource type="Resource" id="step_5"]
 script = ExtResource("2_step")

--- a/Inventory/fases/sequence_editor.gd
+++ b/Inventory/fases/sequence_editor.gd
@@ -23,7 +23,6 @@ const SEQUENCES_DIR = "user://sequences"
 @onready var check_float: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFloat
 @onready var check_double: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckDouble
 @onready var check_short: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckShort
-@onready var check_bool: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckBool
 @onready var check_fp8: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFP8
 @onready var check_fp16: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFP16
 @onready var check_fp_cust: CheckBox = $Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFPCust
@@ -193,7 +192,6 @@ func _show_phase_editor(step: PhaseSequenceStep) -> void:
 		check_float.button_pressed = cfg.use_converter
 		check_double.button_pressed = cfg.allow_double
 		check_short.button_pressed = cfg.allow_short
-		check_bool.button_pressed = cfg.allow_bool
 		check_fp8.button_pressed = cfg.allow_fp8
 		check_fp16.button_pressed = cfg.allow_fp16
 		check_fp_cust.button_pressed = cfg.allow_fp_customization
@@ -211,7 +209,6 @@ func _show_phase_editor(step: PhaseSequenceStep) -> void:
 		check_float.button_pressed = cfg.allow_float
 		check_double.button_pressed = cfg.allow_double
 		check_short.button_pressed = cfg.allow_short
-		check_bool.button_pressed = cfg.allow_bool
 		check_fp8.button_pressed = cfg.allow_fp8
 		check_fp16.button_pressed = cfg.allow_fp16
 		check_calc.button_pressed = false
@@ -231,7 +228,6 @@ func _show_phase_editor(step: PhaseSequenceStep) -> void:
 		check_float.button_pressed = cfg.allow_float
 		check_double.button_pressed = cfg.allow_double
 		check_short.button_pressed = cfg.allow_short
-		check_bool.button_pressed = cfg.allow_bool
 		check_fp8.button_pressed = cfg.allow_fp8
 		check_fp16.button_pressed = cfg.allow_fp16
 		check_calc.button_pressed = false
@@ -280,7 +276,6 @@ func _update_phase_editor_visibility(step: PhaseSequenceStep) -> void:
 	check_float.visible = show_tools
 	check_double.visible = show_tools
 	check_short.visible = show_tools
-	check_bool.visible = show_tools
 	check_fp8.visible = show_tools
 	check_fp16.visible = show_tools
 	check_fp_cust.visible = is_mochila
@@ -336,7 +331,6 @@ func _apply_ui_to_step(step: PhaseSequenceStep) -> void:
 			cfg.use_converter = check_float.button_pressed
 			cfg.allow_double = check_double.button_pressed
 			cfg.allow_short = check_short.button_pressed
-			cfg.allow_bool = check_bool.button_pressed
 			cfg.allow_fp8 = check_fp8.button_pressed
 			cfg.allow_fp16 = check_fp16.button_pressed
 			cfg.allow_fp_customization = check_fp_cust.button_pressed
@@ -358,7 +352,6 @@ func _apply_ui_to_step(step: PhaseSequenceStep) -> void:
 			cfg.allow_float = check_float.button_pressed
 			cfg.allow_double = check_double.button_pressed
 			cfg.allow_short = check_short.button_pressed
-			cfg.allow_bool = check_bool.button_pressed
 			cfg.allow_fp8 = check_fp8.button_pressed
 			cfg.allow_fp16 = check_fp16.button_pressed
 		PhaseSequenceStep.Kind.RAW_MOCHILA:
@@ -380,7 +373,6 @@ func _apply_ui_to_step(step: PhaseSequenceStep) -> void:
 			cfg.allow_float = check_float.button_pressed
 			cfg.allow_double = check_double.button_pressed
 			cfg.allow_short = check_short.button_pressed
-			cfg.allow_bool = check_bool.button_pressed
 			cfg.allow_fp8 = check_fp8.button_pressed
 			cfg.allow_fp16 = check_fp16.button_pressed
 		PhaseSequenceStep.Kind.BINARIO:
@@ -600,7 +592,7 @@ func _on_help_mochila_pressed() -> void:
 	_show_dialog("Mochila e Bancada", "- Capacidade: Quantos bytes a mochila suporta.\n- Slots: Quantos quadrados visíveis existem para soltar itens.\n- Bancada (Pool): A área onde os itens ficam disponíveis para escolha.")
 
 func _on_help_valores_pressed() -> void:
-	_show_dialog("Valores e Tipos", "- Int Mín/Máx: faixa de ints aleatórios.\n- Itens iniciais: 1_i, 3.14_f, 2.5_d, 1_b (vírgulas entre itens).\n- Exportar/Importar CSV usa | entre itens na coluna de itens (ex: 1_i|2_i|3_i).\n- Tipos aleatórios extra: quantidade de IDs sortidos na bancada.")
+	_show_dialog("Valores e Tipos", "- Int Mín/Máx: faixa de ints aleatórios.\n- Itens iniciais: 1_i, 3.14_f, 2.5_d (vírgulas entre itens).\n- Exportar/Importar CSV usa | entre itens na coluna de itens (ex: 1_i|2_i|3_i).\n- Tipos aleatórios extra: quantidade de IDs sortidos na bancada.")
 
 func _on_btn_export_csv_pressed() -> void:
 	var sel = tree.get_selected()
@@ -608,17 +600,17 @@ func _on_btn_export_csv_pressed() -> void:
 	var seq_item = sel if sel.get_metadata(0).type == "sequence" else sel.get_parent()
 	var seq_list: PhaseSequenceList = seq_item.get_metadata(0).data
 	
-	var csv_str = "KIND,CAPACITY,SLOTS_M,SLOTS_P,COLS,MIN,MAX,CSV_ITEMS,RND_POOL,FLOAT,DOUBLE,SHORT,BOOL,FP8,FP16,CALC,FP_CUST,FP8_E,FP8_M,FP16_E,FP16_M\n"
+	var csv_str = "KIND,CAPACITY,SLOTS_M,SLOTS_P,COLS,MIN,MAX,CSV_ITEMS,RND_POOL,FLOAT,DOUBLE,SHORT,FP8,FP16,CALC,FP_CUST,FP8_E,FP8_M,FP16_E,FP16_M\n"
 	for step in seq_list.steps:
 		if step.kind == PhaseSequenceStep.Kind.MOCHILA:
 			var c = step.config_mochila
 			if not c: c = PhaseConfig.new()
 			var items_field := SequenceCsvCodec.items_field_from_backpack_csv(c.initial_backpack_csv)
-			csv_str += "M,%d,%d,%d,%d,%d,%d,%s,%d,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%d\n" % [
+			csv_str += "M,%d,%d,%d,%d,%d,%d,%s,%d,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%d\n" % [
 				c.capacity_bytes, c.backpack_slot_count, c.pool_slot_count, c.pool_grid_columns,
 				c.spawn_int_min, c.spawn_int_max,
 				SequenceCsvCodec.escape_field(items_field), c.random_pool.size(),
-				str(c.use_converter), str(c.allow_double), str(c.allow_short), str(c.allow_bool),
+				str(c.use_converter), str(c.allow_double), str(c.allow_short),
 				str(c.allow_fp8), str(c.allow_fp16), str(c.allow_calc), str(c.allow_fp_customization),
 				c.fp8_exp_bits, c.fp8_mant_bits, c.fp16_exp_bits, c.fp16_mant_bits
 			]
@@ -626,11 +618,11 @@ func _on_btn_export_csv_pressed() -> void:
 			var c = step.config_type_box
 			if not c: c = TypeBoxPhaseConfig.new()
 			var raw_field := SequenceCsvCodec.ITEMS_SEP.join(c.initial_raw_values)
-			csv_str += "T,%d,%d,0,0,0,0,%s,%d,%s,%s,%s,%s,%s,%s,false,false,%d,%d,%d,%d\n" % [
+			csv_str += "T,%d,%d,0,0,0,0,%s,%d,%s,%s,%s,%s,%s,false,false,%d,%d,%d,%d\n" % [
 				c.capacity_bytes, c.box_slot_count,
 				SequenceCsvCodec.escape_field(raw_field),
 				1 if c.randomize_values else 0,
-				str(c.allow_float), str(c.allow_double), str(c.allow_short), str(c.allow_bool),
+				str(c.allow_float), str(c.allow_double), str(c.allow_short),
 				str(c.allow_fp8), str(c.allow_fp16),
 				c.fp8_exp_bits, c.fp8_mant_bits, c.fp16_exp_bits, c.fp16_mant_bits
 			]
@@ -639,11 +631,11 @@ func _on_btn_export_csv_pressed() -> void:
 			if not c:
 				c = RawKnapsackPhaseConfig.new()
 			var raw_field2 := SequenceCsvCodec.ITEMS_SEP.join(c.initial_raw_values)
-			csv_str += "R,%d,%d,%d,%d,0,0,%s,%d,%s,%s,%s,%s,%s,%s,false,false,%d,%d,%d,%d\n" % [
+			csv_str += "R,%d,%d,%d,%d,0,0,%s,%d,%s,%s,%s,%s,%s,false,false,%d,%d,%d,%d\n" % [
 				c.capacity_bytes, c.backpack_slot_count, c.pool_slot_count, c.pool_grid_columns,
 				SequenceCsvCodec.escape_field(raw_field2),
 				1 if c.randomize_values else 0,
-				str(c.allow_float), str(c.allow_double), str(c.allow_short), str(c.allow_bool),
+				str(c.allow_float), str(c.allow_double), str(c.allow_short),
 				str(c.allow_fp8), str(c.allow_fp16),
 				c.fp8_exp_bits, c.fp8_mant_bits, c.fp16_exp_bits, c.fp16_mant_bits
 			]
@@ -651,7 +643,7 @@ func _on_btn_export_csv_pressed() -> void:
 			var bc: BinaryPhaseConfig = step.config_binario
 			if not bc:
 				bc = ConfigGenerator.generate_binary_config()
-			csv_str += "B,%d,%d,0,0,0,0,,0,false,false,false,false,false,false,false,false,4,3,5,10\n" % [
+			csv_str += "B,%d,%d,0,0,0,0,,0,false,false,false,false,false,false,false,4,3,5,10\n" % [
 				bc.fixed_left_bit, bc.fixed_right_bit
 			]
 			
@@ -666,6 +658,9 @@ func _on_btn_import_csv_pressed() -> void:
 		
 	var lines = csv_str.split("\n")
 	var seq_list = PhaseSequenceList.new()
+	var col_idx: Dictionary = {}
+	for hi in lines[0].split(",").size():
+		col_idx[lines[0].split(",")[hi].strip_edges()] = hi
 	
 	for i in range(1, lines.size()):
 		var line = lines[i].strip_edges()
@@ -689,26 +684,28 @@ func _on_btn_import_csv_pressed() -> void:
 			var rp_size = int(parts[8])
 			if rp_size > 0:
 				c.random_pool = ConfigGenerator._random_int_items(rp_size)
-			if parts.size() > 9:
-				c.use_converter = (parts[9] == "true")
-			if parts.size() > 10:
-				c.allow_double = (parts[10] == "true")
-			if parts.size() > 11:
-				c.allow_short = (parts[11] == "true")
-			if parts.size() > 12:
-				c.allow_bool = (parts[12] == "true")
-			if parts.size() > 13:
-				c.allow_fp8 = (parts[13] == "true")
-			if parts.size() > 14:
-				c.allow_fp16 = (parts[14] == "true")
-			if parts.size() > 15:
-				c.allow_calc = (parts[15] == "true")
-			if parts.size() >= 21:
-				c.allow_fp_customization = (parts[16] == "true")
-				c.fp8_exp_bits = int(parts[17])
-				c.fp8_mant_bits = int(parts[18])
-				c.fp16_exp_bits = int(parts[19])
-				c.fp16_mant_bits = int(parts[20])
+			if col_idx.has("FLOAT") and col_idx["FLOAT"] < parts.size():
+				c.use_converter = (parts[col_idx["FLOAT"]] == "true")
+			if col_idx.has("DOUBLE") and col_idx["DOUBLE"] < parts.size():
+				c.allow_double = (parts[col_idx["DOUBLE"]] == "true")
+			if col_idx.has("SHORT") and col_idx["SHORT"] < parts.size():
+				c.allow_short = (parts[col_idx["SHORT"]] == "true")
+			if col_idx.has("FP8") and col_idx["FP8"] < parts.size():
+				c.allow_fp8 = (parts[col_idx["FP8"]] == "true")
+			if col_idx.has("FP16") and col_idx["FP16"] < parts.size():
+				c.allow_fp16 = (parts[col_idx["FP16"]] == "true")
+			if col_idx.has("CALC") and col_idx["CALC"] < parts.size():
+				c.allow_calc = (parts[col_idx["CALC"]] == "true")
+			if col_idx.has("FP_CUST") and col_idx["FP_CUST"] < parts.size():
+				c.allow_fp_customization = (parts[col_idx["FP_CUST"]] == "true")
+			if col_idx.has("FP8_E") and col_idx["FP8_E"] < parts.size():
+				c.fp8_exp_bits = int(parts[col_idx["FP8_E"]])
+			if col_idx.has("FP8_M") and col_idx["FP8_M"] < parts.size():
+				c.fp8_mant_bits = int(parts[col_idx["FP8_M"]])
+			if col_idx.has("FP16_E") and col_idx["FP16_E"] < parts.size():
+				c.fp16_exp_bits = int(parts[col_idx["FP16_E"]])
+			if col_idx.has("FP16_M") and col_idx["FP16_M"] < parts.size():
+				c.fp16_mant_bits = int(parts[col_idx["FP16_M"]])
 			step.config_mochila = c
 		elif parts[0] == "R":
 			step.kind = PhaseSequenceStep.Kind.RAW_MOCHILA
@@ -725,23 +722,24 @@ func _on_btn_import_csv_pressed() -> void:
 					raw_vals2.append(s2)
 			rc.initial_raw_values = raw_vals2
 			rc.randomize_values = (int(parts[8]) > 0)
-			if parts.size() > 9:
-				rc.allow_float = (parts[9] == "true")
-			if parts.size() > 10:
-				rc.allow_double = (parts[10] == "true")
-			if parts.size() > 11:
-				rc.allow_short = (parts[11] == "true")
-			if parts.size() > 12:
-				rc.allow_bool = (parts[12] == "true")
-			if parts.size() > 13:
-				rc.allow_fp8 = (parts[13] == "true")
-			if parts.size() > 14:
-				rc.allow_fp16 = (parts[14] == "true")
-			if parts.size() >= 21:
-				rc.fp8_exp_bits = int(parts[17])
-				rc.fp8_mant_bits = int(parts[18])
-				rc.fp16_exp_bits = int(parts[19])
-				rc.fp16_mant_bits = int(parts[20])
+			if col_idx.has("FLOAT") and col_idx["FLOAT"] < parts.size():
+				rc.allow_float = (parts[col_idx["FLOAT"]] == "true")
+			if col_idx.has("DOUBLE") and col_idx["DOUBLE"] < parts.size():
+				rc.allow_double = (parts[col_idx["DOUBLE"]] == "true")
+			if col_idx.has("SHORT") and col_idx["SHORT"] < parts.size():
+				rc.allow_short = (parts[col_idx["SHORT"]] == "true")
+			if col_idx.has("FP8") and col_idx["FP8"] < parts.size():
+				rc.allow_fp8 = (parts[col_idx["FP8"]] == "true")
+			if col_idx.has("FP16") and col_idx["FP16"] < parts.size():
+				rc.allow_fp16 = (parts[col_idx["FP16"]] == "true")
+			if col_idx.has("FP8_E") and col_idx["FP8_E"] < parts.size():
+				rc.fp8_exp_bits = int(parts[col_idx["FP8_E"]])
+			if col_idx.has("FP8_M") and col_idx["FP8_M"] < parts.size():
+				rc.fp8_mant_bits = int(parts[col_idx["FP8_M"]])
+			if col_idx.has("FP16_E") and col_idx["FP16_E"] < parts.size():
+				rc.fp16_exp_bits = int(parts[col_idx["FP16_E"]])
+			if col_idx.has("FP16_M") and col_idx["FP16_M"] < parts.size():
+				rc.fp16_mant_bits = int(parts[col_idx["FP16_M"]])
 			step.config_raw_mochila = rc
 		elif parts[0] == "T":
 			step.kind = PhaseSequenceStep.Kind.TYPE_BOX
@@ -756,23 +754,24 @@ func _on_btn_import_csv_pressed() -> void:
 					vals.append(s)
 			c.initial_raw_values = vals
 			c.randomize_values = (int(parts[8]) > 0)
-			if parts.size() > 9:
-				c.allow_float = (parts[9] == "true")
-			if parts.size() > 10:
-				c.allow_double = (parts[10] == "true")
-			if parts.size() > 11:
-				c.allow_short = (parts[11] == "true")
-			if parts.size() > 12:
-				c.allow_bool = (parts[12] == "true")
-			if parts.size() > 13:
-				c.allow_fp8 = (parts[13] == "true")
-			if parts.size() > 14:
-				c.allow_fp16 = (parts[14] == "true")
-			if parts.size() >= 21:
-				c.fp8_exp_bits = int(parts[17])
-				c.fp8_mant_bits = int(parts[18])
-				c.fp16_exp_bits = int(parts[19])
-				c.fp16_mant_bits = int(parts[20])
+			if col_idx.has("FLOAT") and col_idx["FLOAT"] < parts.size():
+				c.allow_float = (parts[col_idx["FLOAT"]] == "true")
+			if col_idx.has("DOUBLE") and col_idx["DOUBLE"] < parts.size():
+				c.allow_double = (parts[col_idx["DOUBLE"]] == "true")
+			if col_idx.has("SHORT") and col_idx["SHORT"] < parts.size():
+				c.allow_short = (parts[col_idx["SHORT"]] == "true")
+			if col_idx.has("FP8") and col_idx["FP8"] < parts.size():
+				c.allow_fp8 = (parts[col_idx["FP8"]] == "true")
+			if col_idx.has("FP16") and col_idx["FP16"] < parts.size():
+				c.allow_fp16 = (parts[col_idx["FP16"]] == "true")
+			if col_idx.has("FP8_E") and col_idx["FP8_E"] < parts.size():
+				c.fp8_exp_bits = int(parts[col_idx["FP8_E"]])
+			if col_idx.has("FP8_M") and col_idx["FP8_M"] < parts.size():
+				c.fp8_mant_bits = int(parts[col_idx["FP8_M"]])
+			if col_idx.has("FP16_E") and col_idx["FP16_E"] < parts.size():
+				c.fp16_exp_bits = int(parts[col_idx["FP16_E"]])
+			if col_idx.has("FP16_M") and col_idx["FP16_M"] < parts.size():
+				c.fp16_mant_bits = int(parts[col_idx["FP16_M"]])
 			step.config_type_box = c
 		else:
 			step.kind = PhaseSequenceStep.Kind.BINARIO

--- a/Inventory/fases/sequence_editor.tscn
+++ b/Inventory/fases/sequence_editor.tscn
@@ -325,10 +325,6 @@ text = "Permitir Conversor Double (8 bytes)"
 layout_mode = 2
 text = "Permitir Conversor Short (0.5 slot)"
 
-[node name="CheckBool" type="CheckBox" parent="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor"]
-layout_mode = 2
-text = "Permitir Conversor Boolean (0.25 slot)"
-
 [node name="CheckFP8" type="CheckBox" parent="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor"]
 layout_mode = 2
 text = "Permitir Conversor FP8 (1 byte)"
@@ -377,7 +373,6 @@ text = "Alterações são salvas ao trocar de fase ou ao clicar em Salvar."
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFloat" to="." method="_on_bool_param_changed"]
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckDouble" to="." method="_on_bool_param_changed"]
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckShort" to="." method="_on_bool_param_changed"]
-[connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckBool" to="." method="_on_bool_param_changed"]
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFP8" to="." method="_on_bool_param_changed"]
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFP16" to="." method="_on_bool_param_changed"]
 [connection signal="toggled" from="Panel/VBoxContainer/HSplitContainer/RightPanel/VBoxContainer/PhaseEditor/CheckFPCust" to="." method="_on_bool_param_changed"]

--- a/Inventory/fases/type_box_phase.gd
+++ b/Inventory/fases/type_box_phase.gd
@@ -88,7 +88,6 @@ func _create_boxes():
 	if config.allow_double: types.append({"type": ItemRef.DataType.DOUBLE, "name": "Double", "color": Color.MAGENTA})
 	if config.allow_fp8: types.append({"type": ItemRef.DataType.FP8, "name": "FP8", "color": Color.VIOLET})
 	if config.allow_fp16: types.append({"type": ItemRef.DataType.FP16, "name": "FP16", "color": Color.GOLD})
-	if config.allow_bool: types.append({"type": ItemRef.DataType.BOOLEAN, "name": "Boolean", "color": Color.GREEN})
 	
 	for t in types:
 		var box_container = HBoxContainer.new()
@@ -146,7 +145,7 @@ func _populate_pool():
 			match case_type:
 				0: values_to_spawn.append("%.4f" % randf_range(-1.0, 1.0)) # Exige float ou double (muita precisão)
 				1: values_to_spawn.append(str(randi_range(33000, 50000))) # Estoura short_int, exige int
-				2: values_to_spawn.append(str(randi_range(0, 1))) # Ideal para boolean
+				2: values_to_spawn.append(str(randi_range(0, 1)))
 				3: values_to_spawn.append("%.1f" % randf_range(100.0, 1000.0)) # Float comum
 	else:
 		values_to_spawn = config.initial_raw_values
@@ -321,5 +320,4 @@ func _get_type_name(dt) -> String:
 	if dt == ItemRef.DataType.DOUBLE: return "Double"
 	if dt == ItemRef.DataType.FP8: return "FP8"
 	if dt == ItemRef.DataType.FP16: return "FP16"
-	if dt == ItemRef.DataType.BOOLEAN: return "Boolean"
 	return "Desconhecido"

--- a/Inventory/fases/type_box_phase_config.gd
+++ b/Inventory/fases/type_box_phase_config.gd
@@ -20,7 +20,6 @@ extends Resource
 @export var allow_double: bool = false
 @export var allow_fp8: bool = false
 @export var allow_fp16: bool = false
-@export var allow_bool: bool = false
 
 @export var fp8_exp_bits: int = 4
 @export var fp8_mant_bits: int = 3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ O Code Orbs é um jogo educativo desenvolvido para desmistificar os conceitos ma
 Muitas vezes, iniciantes em programação desistem devido à alta carga de abstração inicial. O Code Orbs transforma essa abstração em mecânicas visuais, onde o jogador manipula orbes de energia (dados) e os organiza em recipientes (variáveis). Baseado na Arquitetura de Von Neumann e na Teoria de Tipos de Pierce, o jogo cria uma ponte entre a ação lúdica e a sintaxe real em Python.
 
 🎮 Mecânicas Principais
-Sistema de Orbes: Cada cor e forma representa um tipo de dado (int, float, string, bool).
+Sistema de Orbes: Cada cor e forma representa um tipo de dado (int, float, string, etc.).
 
 Recipientes de Memória: Representação visual de variáveis onde o jogador deve respeitar a tipagem para resolver puzzles.
 

--- a/gerador.py
+++ b/gerador.py
@@ -24,8 +24,6 @@ class GeradorCodigoPython:
     def detectar_tipo(self, valor: str):
         """Detecta o tipo do valor e retorna tipo e valor convertido"""
         valor = valor.strip()
-        if valor.lower() in ['true', 'false']:
-            return 'bool', valor.lower() == 'true'
         if '.' in valor and valor.replace('.', '').replace('-', '').isdigit():
             return 'float', float(valor)
         if valor.replace('-', '').isdigit():
@@ -57,8 +55,6 @@ class GeradorCodigoPython:
         for nome_var, tipo, val in variaveis:
             if tipo == "str":
                 codigo_linhas.append(f'{nome_var}: {tipo} = "{val}"')
-            elif tipo == "bool":
-                codigo_linhas.append(f"{nome_var}: {tipo} = {str(val)}")
             else:
                 codigo_linhas.append(f"{nome_var}: {tipo} = {val}")
 


### PR DESCRIPTION
- Alterado o mapeamento de tipos no controlador para substituir 'bool' por 'int'.
- Removidos os métodos e referências relacionados a booleanos em diversos arquivos, incluindo gerador e item.
- Atualizadas as expressões para tratar valores booleanos como inteiros (0 e 1).
- Ajustadas as configurações de fase para desabilitar a opção de booleanos, simplificando a lógica de conversão e manipulação de dados.